### PR TITLE
refactor: remove unused imports in xtream manager

### DIFF
--- a/app/xtream_manager.py
+++ b/app/xtream_manager.py
@@ -5,13 +5,12 @@ import re
 import json
 import zlib
 import time
-import html
 import urllib.parse
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, Iterable, DefaultDict
+from typing import Any, Dict, List, Optional, Tuple, Iterable
 from collections import defaultdict
 
-from fastapi import APIRouter, HTTPException, Response, Request, Depends
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import PlainTextResponse, JSONResponse, RedirectResponse
 
 # ====== PATHS & ENV ======


### PR DESCRIPTION
## Summary
- drop unused imports from xtream manager

## Testing
- `python -m py_compile app/xtream_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68acecd18380832ca03abeeb648ea27d