### PR TITLE
refactor: remove unused Response import

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional
 
 import httpx
 from fastapi import FastAPI, HTTPException, Query, Body, Path
-from fastapi.responses import Response, JSONResponse, RedirectResponse, PlainTextResponse, FileResponse, HTMLResponse
+from fastapi.responses import JSONResponse, RedirectResponse, PlainTextResponse, FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, AnyHttpUrl


### PR DESCRIPTION
## Summary
- drop unused `Response` import in main

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68acecc25628832ca57fbdb0bead4cab