### PR TITLE
refactor: drop unused sys import

### DIFF
--- a/app/adapter.py
+++ b/app/adapter.py
@@ -1,4 +1,3 @@
-import sys
 import json
 import subprocess
 from typing import Optional


### PR DESCRIPTION
## Summary
- remove unused `sys` import in adapter module

## Testing
- `python -m py_compile app/adapter.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acecb3591c832cb1c62bec8953cead