### PR TITLE
Fix config path in anime scrapers

### DIFF
--- a/resolvers/animesaturn.py
+++ b/resolvers/animesaturn.py
@@ -14,7 +14,7 @@ import json
 import urllib.parse
 import argparse
 import os
-with open(os.path.join(os.path.dirname(__file__), '../../config/domains.json'), encoding='utf-8') as f:
+with open(os.path.join(os.path.dirname(__file__), 'config/domains.json'), encoding='utf-8') as f:
     DOMAINS = json.load(f)
 BASE_URL = f"https://{DOMAINS['animesaturn']}"
 USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"

--- a/resolvers/animeunity_scraper.py
+++ b/resolvers/animeunity_scraper.py
@@ -15,7 +15,7 @@ import sys
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse, urljoin, unquote
 import json, os
-with open(os.path.join(os.path.dirname(__file__), '../../config/domains.json'), encoding='utf-8') as f:
+with open(os.path.join(os.path.dirname(__file__), 'config/domains.json'), encoding='utf-8') as f:
     DOMAINS = json.load(f)
 BASE_URL = f"https://www.{DOMAINS['animeunity']}"
 USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"

--- a/resolvers/animeworld_scraper.py
+++ b/resolvers/animeworld_scraper.py
@@ -16,7 +16,7 @@ import requests
 from bs4 import BeautifulSoup
 
 BASE_DIR = os.path.dirname(__file__)
-with open(os.path.join(BASE_DIR, '../../config/domains.json'), encoding='utf-8') as f:
+with open(os.path.join(BASE_DIR, 'config/domains.json'), encoding='utf-8') as f:
     DOMAINS = json.load(f)
 AW_HOST = DOMAINS.get('animeworld', 'animeworld.so')
 BASE_URL = f"https://{AW_HOST}"


### PR DESCRIPTION
## Summary
- point anime unity, anime world, and anime saturn scrapers to resolver-local domains.json

## Testing
- `python resolvers/animeunity_scraper.py -h`
- `python resolvers/animeworld_scraper.py -h`
- `python resolvers/animesaturn.py -h`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acefa585b4832caed75ccaee5fe6b1