### PR TITLE
Refactor domains.json location

### DIFF
--- a/app/registry.py
+++ b/app/registry.py
@@ -2,7 +2,7 @@ import os, json
 from pathlib import Path
 
 RESOLVERS_DIR = os.environ.get("RESOLVERS_DIR", "/opt/external-resolvers")
-DOMAINS_JSON  = os.environ.get("DOMAINS_JSON", "/app/config/domains.json")
+DOMAINS_JSON  = os.environ.get("DOMAINS_JSON", "/opt/external-resolvers/config/domains.json")
 
 if os.path.exists(DOMAINS_JSON):
     with open(DOMAINS_JSON, "r", encoding="utf-8") as f:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       # Resolvers esterni (sola lettura)
       - ./resolvers:/opt/external-resolvers:ro
       # (opzionale) Sovrascrivi solo il domains.json usato dai resolvers
-      - ./resolvers/config/domains.json:/app/config/domains.json:ro
+      - ./resolvers/config/domains.json:/opt/external-resolvers/config/domains.json:ro
     environment:
       # Queste variabili non sono obbligatorie perché il tuo main.py ha default sensati,
       # ma le espongo per chiarezza (puoi anche rimuoverle):
@@ -26,7 +26,7 @@ services:
       STATIC_DIR: /app/app/static
       # Per i resolvers Python esterni che le leggono:
       RESOLVERS_DIR: /opt/external-resolvers
-      DOMAINS_JSON: /app/config/domains.json
+      DOMAINS_JSON: /opt/external-resolvers/config/domains.json
       PYTHONUNBUFFERED: "1"
       TZ: "Europe/Rome"
     restart: unless-stopped

--- a/resolvers/animesaturn.py
+++ b/resolvers/animesaturn.py
@@ -14,7 +14,7 @@ import json
 import urllib.parse
 import argparse
 import os
-with open(os.path.join(os.path.dirname(__file__), '../../config/domains.json'), encoding='utf-8') as f:
+with open(os.path.join(os.path.dirname(__file__), 'config/domains.json'), encoding='utf-8') as f:
     DOMAINS = json.load(f)
 BASE_URL = f"https://{DOMAINS['animesaturn']}"
 USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"

--- a/resolvers/animeunity_scraper.py
+++ b/resolvers/animeunity_scraper.py
@@ -15,7 +15,7 @@ import sys
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse, urljoin, unquote
 import json, os
-with open(os.path.join(os.path.dirname(__file__), '../../config/domains.json'), encoding='utf-8') as f:
+with open(os.path.join(os.path.dirname(__file__), 'config/domains.json'), encoding='utf-8') as f:
     DOMAINS = json.load(f)
 BASE_URL = f"https://www.{DOMAINS['animeunity']}"
 USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"

--- a/resolvers/animeworld_scraper.py
+++ b/resolvers/animeworld_scraper.py
@@ -16,7 +16,7 @@ import requests
 from bs4 import BeautifulSoup
 
 BASE_DIR = os.path.dirname(__file__)
-with open(os.path.join(BASE_DIR, '../../config/domains.json'), encoding='utf-8') as f:
+with open(os.path.join(BASE_DIR, 'config/domains.json'), encoding='utf-8') as f:
     DOMAINS = json.load(f)
 AW_HOST = DOMAINS.get('animeworld', 'animeworld.so')
 BASE_URL = f"https://{AW_HOST}"


### PR DESCRIPTION
## Summary
- map `domains.json` from resolver config into `/opt/external-resolvers` instead of `/app/config`
- read domain map from resolver directory in registry and resolvers

## Testing
- `python -m py_compile app/registry.py resolvers/animesaturn.py resolvers/animeunity_scraper.py resolvers/animeworld_scraper.py`
- `docker compose -f docker-compose.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acefb4a334832cbfa8f237ab26d7af