### PR TITLE
Add container extension field to live streams

### DIFF
--- a/app/xtream_manager.py
+++ b/app/xtream_manager.py
@@ -352,6 +352,7 @@ def build_live_streams(request: Request, items: Iterable[M3UItem]) -> Tuple[List
             "category_id": cat_id,
             "added": "",
             "custom_sid": "",
+            "container_extension": "m3u8",
             "direct_source": make_direct_live(request, it.url)
         })
         num += 1


### PR DESCRIPTION
## Summary
- include `container_extension` for Xtream live stream entries

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acfc9d9b78832cb43fcd666fdc09da