### PR TITLE
Normalize live group names

### DIFF
--- a/app/xtream_manager.py
+++ b/app/xtream_manager.py
@@ -214,7 +214,7 @@ def normalize_group_for_type(group: str, typ: str) -> str:
     elif typ == "series":
         g = re.sub(r"^(serietv|serie)\s*-\s*", "", g, flags=re.I)
     elif typ == "live":
-        pass
+        g = re.sub(r"^(live|tv)\s*-\s*", "", g, flags=re.I)
     return g or "Generale"
 
 # ====== DIRECT SOURCE ======


### PR DESCRIPTION
## Summary
- Strip "live"/"tv" prefixes when normalizing groups for live streams to ensure stable category mapping.

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acfcae5484832cba8161fbb9fe0b45