### PR TITLE
Fix admin panel script identifiers and formatting

### DIFF
--- a/app/static/admin/admin.js
+++ b/app/static/admin/admin.js
@@ -95,7 +95,9 @@ async function loadLists(){
         <div class="row-main">
           <div><b>${it.name}</b></div>
           <div class="muted">${it.url}</div>
-          <div>Tipo: <b>${it.mode}</b> &nbsp; • &nbsp; Aggiorna ogni <input class="hrs" type="number" min="1" value="${it.every_hours}"/> ore</div>
+          <div>Tipo: <b>${it.mode}</b> &nbsp; • &nbsp; Aggiorna ogni
+            <input class="hrs" type="number" min="1" value="${it.every_hours}"/> ore
+          </div>
           <div class="muted">Ultimo refresh: ${it.last_refresh ? new Date(it.last_refresh*1000).toLocaleString() : "mai"}</div>
         </div>
         <div class="row-ops">
@@ -186,7 +188,12 @@ function buildServerUrl(x){
   return base + "/xtream/" + x.id;
 }
 function buildFullM3UUrl(x){
-  return buildServerUrl(x) + "/get.php?username=" + encodeURIComponent(x.username) + "&password=" + encodeURIComponent(x.password) + "&type=m3u&output=ts";
+  return (
+    buildServerUrl(x) +
+    "/get.php?username=" + encodeURIComponent(x.username) +
+    "&password=" + encodeURIComponent(x.password) +
+    "&type=m3u&output=ts"
+  );
 }
 
 // ---------------- Xtream: CRUD ----------------


### PR DESCRIPTION
## Summary
- keep playlist update interval field intact to prevent broken identifiers
- simplify full M3U URL builder with multi-line expression

## Testing
- `node --check app/static/admin/admin.js`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad065d359c832caf5eefd371d18f89