### PR TITLE
Strip credentials before saving and comparison

### DIFF
--- a/app/xtream_manager.py
+++ b/app/xtream_manager.py
@@ -124,8 +124,8 @@ def admin_xtreams_add(payload: Dict[str, Any]):
     it = {
         "id": f"xt_{hex(crc32_num((payload.get('name') or '') + str(now_ts())))[2:][:8]}",
         "name": payload.get("name") or "Xtream",
-        "username": payload.get("username") or "",
-        "password": payload.get("password") or "",
+        "username": (payload.get("username") or "").strip(),
+        "password": (payload.get("password") or "").strip(),
         "live_list_ids": payload.get("live_list_ids") or [],
         "movie_list_ids": payload.get("movie_list_ids") or [],
         "series_list_ids": payload.get("series_list_ids") or [],
@@ -401,6 +401,8 @@ def build_live_streams(request: Request, items: Iterable[M3UItem]) -> Tuple[List
 
 # ====== AUTH XTREAM ======
 def require_xtream(xt_id: str, username: str, password: str) -> Dict[str, Any]:
+    username = username.strip()
+    password = password.strip()
     xs = _xtreams()
     for row in xs:
         if row.get("id") == xt_id and row.get("username") == username and row.get("password") == password:


### PR DESCRIPTION
## Summary
- Normalize username and password fields before saving Xtream configurations
- Strip credentials before comparing them during Xtream auth

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad0e9bd3e4832c99b223b0acbd7b54