### PR TITLE
Support series path in TV pattern

### DIFF
--- a/app/xtream_manager.py
+++ b/app/xtream_manager.py
@@ -178,18 +178,20 @@ def _read_playlist(pl_id: str) -> List[M3UItem]:
 
 # ====== CLASSIFICAZIONE ======
 MOVIE_RE = re.compile(r"/movie/(\d+)", re.I)
-TV_RE    = re.compile(r"/tv/(\d+)/(?:season/)?(\d+)/(\d+)", re.I)
-TV_RE_SHORT = re.compile(r"/tv/(\d+)/(\d+)/(\d+)", re.I)
+TV_RE    = re.compile(r"/(?:tv|series)/(\d+)/(?:season/)?(\d+)/(\d+)", re.I)
+TV_RE_SHORT = re.compile(r"/(?:tv|series)/(\d+)/(\d+)/(\d+)", re.I)
 
 def try_extract_movie_id(url: str) -> Optional[str]:
     m = MOVIE_RE.search(url)
     return m.group(1) if m else None
 
 def try_extract_tv_triplet(url: str) -> Optional[Tuple[str, int, int]]:
-    m = TV_RE.search(url) or TV_RE_SHORT.search(url)
-    if not m: return None
-    sid, season, episode = m.group(1), int(m.group(2)), int(m.group(3))
-    return sid, season, episode
+    for rgx in (TV_RE, TV_RE_SHORT):
+        m = rgx.search(url)
+        if m:
+            sid, season, episode = m.group(1), int(m.group(2)), int(m.group(3))
+            return sid, season, episode
+    return None
 
 def guess_is_series(item: M3UItem) -> bool:
     if try_extract_tv_triplet(item.url): return True

--- a/tests/test_series_regex.py
+++ b/tests/test_series_regex.py
@@ -1,0 +1,43 @@
+import importlib
+import pathlib
+import sys
+
+import pytest
+
+
+class DummyRequest:
+    base_url = "http://testserver/"
+
+
+@pytest.fixture
+def xm(monkeypatch, tmp_path):
+    monkeypatch.setenv("CONFIG_DIR", str(tmp_path))
+    # ensure repository root is in sys.path for module import
+    root = pathlib.Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(root))
+    import app.xtream_manager as module
+    importlib.reload(module)
+    return module
+
+
+def test_try_extract_tv_triplet_series(xm):
+    url1 = "http://host/series/123/season/1/2"
+    url2 = "http://host/series/123/1/2"
+    assert xm.try_extract_tv_triplet(url1) == ("123", 1, 2)
+    assert xm.try_extract_tv_triplet(url2) == ("123", 1, 2)
+
+
+def test_build_series_collections_series(xm):
+    item = xm.M3UItem(
+        title="My Show S01E02",
+        url="http://host/series/123/season/1/2",
+        attrs={},
+        group="Serie",
+        tvg_id="",
+        tvg_logo="",
+        raw="",
+    )
+    series_map, cat_map = xm.build_series_collections(DummyRequest(), [item])
+    assert "123" in series_map
+    episodes = series_map["123"]["episodes_by_season"]["1"]
+    assert episodes[0]["title"] == "S01E02"


### PR DESCRIPTION
## Summary
- allow `/series/` URLs in TV regex patterns
- handle updated patterns in `try_extract_tv_triplet`
- test series pattern parsing and collection building

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad0e745458832cb25e949992538b74