### PR TITLE
Handle series URLs in TV stream parsing

### DIFF
--- a/app/xtream_manager.py
+++ b/app/xtream_manager.py
@@ -178,18 +178,20 @@ def _read_playlist(pl_id: str) -> List[M3UItem]:
 
 # ====== CLASSIFICAZIONE ======
 MOVIE_RE = re.compile(r"/movie/(\d+)", re.I)
-TV_RE    = re.compile(r"/tv/(\d+)/(?:season/)?(\d+)/(\d+)", re.I)
-TV_RE_SHORT = re.compile(r"/tv/(\d+)/(\d+)/(\d+)", re.I)
+TV_RE    = re.compile(r"/(?:tv|series)/(\d+)/(?:season/)?(\d+)/(\d+)", re.I)
+TV_RE_SHORT = re.compile(r"/(?:tv|series)/(\d+)/(\d+)/(\d+)", re.I)
 
 def try_extract_movie_id(url: str) -> Optional[str]:
     m = MOVIE_RE.search(url)
     return m.group(1) if m else None
 
 def try_extract_tv_triplet(url: str) -> Optional[Tuple[str, int, int]]:
-    m = TV_RE.search(url) or TV_RE_SHORT.search(url)
-    if not m: return None
-    sid, season, episode = m.group(1), int(m.group(2)), int(m.group(3))
-    return sid, season, episode
+    for rgx in (TV_RE, TV_RE_SHORT):
+        m = rgx.search(url)
+        if m:
+            sid, season, episode = m.group(1), int(m.group(2)), int(m.group(3))
+            return sid, season, episode
+    return None
 
 def guess_is_series(item: M3UItem) -> bool:
     if try_extract_tv_triplet(item.url): return True

--- a/tests/test_xtream_series.py
+++ b/tests/test_xtream_series.py
@@ -1,0 +1,55 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+
+from starlette.requests import Request
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+def import_xtm(tmp_path):
+    os.environ["APP_DIR"] = str(tmp_path)
+    return importlib.reload(importlib.import_module("app.xtream_manager"))
+
+
+def make_request():
+    return Request({
+        "type": "http",
+        "scheme": "http",
+        "server": ("test", 80),
+        "path": "/",
+        "headers": [],
+    })
+
+
+def test_try_extract_tv_triplet_series(tmp_path):
+    xtm = import_xtm(tmp_path)
+    url1 = "http://example.com/series/123/season/4/5"
+    url2 = "http://example.com/series/123/4/5"
+    assert xtm.try_extract_tv_triplet(url1) == ("123", 4, 5)
+    assert xtm.try_extract_tv_triplet(url2) == ("123", 4, 5)
+
+
+def test_build_series_collections_with_series_urls(tmp_path):
+    xtm = import_xtm(tmp_path)
+    url = "http://example.com/series/123/season/2/3"
+    item = xtm.M3UItem(
+        title="My Show S02E03",
+        url=url,
+        attrs={},
+        group="Serie",
+        tvg_id="",
+        tvg_logo="",
+        raw="",
+    )
+    req = make_request()
+    series_map, cat_map = xtm.build_series_collections(req, [item])
+    assert "123" in series_map
+    sm = series_map["123"]
+    assert "2" in sm["episodes_by_season"]
+    ep = sm["episodes_by_season"]["2"][0]
+    assert ep["id"] == "123-S02E03"


### PR DESCRIPTION
## Summary
- extend TV regexes to match `/series/` URLs
- iterate over regex list when extracting TV id/season/episode
- test parsing and collection of series items from `/series/` paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad6177d550832cbb9236da55d774e6