### PR TITLE
feat: allow editing playlists and xtream configs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -403,6 +403,8 @@ def admin_add_playlist(data: PlaylistCreate):
     return {"ok": True, "id": pid}
 
 class PlaylistUpdate(BaseModel):
+    name: Optional[str] = None
+    url: Optional[str] = None
     every_hours: Optional[int] = None
     refresh: bool = False
 
@@ -412,6 +414,12 @@ async def admin_update_playlist(pid: str = Path(...), data: PlaylistUpdate = Bod
     it = _find_playlist(items, pid)
     if not it:
         raise HTTPException(status_code=404, detail="Playlist non trovata")
+
+    if data.name is not None:
+        it["name"] = data.name.strip()
+
+    if data.url is not None:
+        it["url"] = data.url.strip()
 
     if data.every_hours is not None:
         it["every_hours"] = max(1, int(data.every_hours))

--- a/app/static/admin/admin.js
+++ b/app/static/admin/admin.js
@@ -102,6 +102,7 @@ async function loadLists(){
         </div>
         <div class="row-ops">
           <button class="small" data-act="refresh">Aggiorna</button>
+          <button class="small" data-act="edit">Modifica</button>
           <button class="small" data-act="copy">Copia link</button>
           <button class="small danger" data-act="del">Elimina</button>
         </div>
@@ -109,6 +110,14 @@ async function loadLists(){
       row.querySelector('[data-act="refresh"]').onclick = async ()=>{
         const hrs = parseInt(row.querySelector(".hrs").value,10)||12;
         await jpost(`/admin/playlists/${it.id}/update`, { every_hours: hrs, refresh: true });
+        await loadLists();
+        await populateXtreamSelects();
+      };
+      row.querySelector('[data-act="edit"]').onclick = async ()=>{
+        const name = prompt("Nuovo nome", it.name);
+        if(!name) return;
+        const url = prompt("Nuovo URL", it.url) || it.url;
+        await jpost(`/admin/playlists/${it.id}/update`, { name, url });
         await loadLists();
         await populateXtreamSelects();
       };
@@ -243,6 +252,7 @@ async function loadXtreams(){
         </div>
         <div class="row-ops">
           <button class="small" data-act="refresh">Aggiorna</button>
+          <button class="small" data-act="edit">Modifica</button>
           <button class="small" data-act="copy-server">Copia URL server</button>
           <button class="small" data-act="copy-full">Copia URL completa</button>
           <button class="small danger" data-act="del">Elimina</button>
@@ -251,6 +261,26 @@ async function loadXtreams(){
       row.querySelector('[data-act="refresh"]').onclick = async ()=>{
         const hrs = parseInt(row.querySelector(".hrs").value,10)||12;
         await jpost(`/admin/xtreams/${x.id}/update`, { every_hours: hrs, refresh: true });
+        await loadXtreams();
+      };
+      row.querySelector('[data-act="edit"]').onclick = async ()=>{
+        const name = prompt("Nome", x.name);
+        if(!name) return;
+        const username = prompt("Username", x.username) || x.username;
+        const password = prompt("Password", x.password) || x.password;
+        const live = prompt("ID playlist Live (separate da virgola)", x.live_list_ids.join(",")) || x.live_list_ids.join(",");
+        const movie = prompt("ID playlist Film (separate da virgola)", x.movie_list_ids.join(",")) || x.movie_list_ids.join(",");
+        const series = prompt("ID playlist Serie (separate da virgola)", x.series_list_ids.join(",")) || x.series_list_ids.join(",");
+        const mixed = prompt("ID playlist Miste (separate da virgola)", x.mixed_list_ids.join(",")) || x.mixed_list_ids.join(",");
+        await jpost(`/admin/xtreams/${x.id}/update`, {
+          name,
+          username,
+          password,
+          live_list_ids: live.split(",").map(s=>s.trim()).filter(Boolean),
+          movie_list_ids: movie.split(",").map(s=>s.trim()).filter(Boolean),
+          series_list_ids: series.split(",").map(s=>s.trim()).filter(Boolean),
+          mixed_list_ids: mixed.split(",").map(s=>s.trim()).filter(Boolean)
+        });
         await loadXtreams();
       };
       row.querySelector('[data-act="del"]').onclick = async ()=>{

--- a/app/xtream_manager.py
+++ b/app/xtream_manager.py
@@ -154,6 +154,15 @@ def admin_xtreams_update(xt_id: str, payload: Dict[str, Any]):
             break
     if not found:
         raise HTTPException(404, "Not Found")
+    if "name" in payload:
+        found["name"] = payload.get("name")
+    if "username" in payload:
+        found["username"] = (payload.get("username") or "").strip()
+    if "password" in payload:
+        found["password"] = payload.get("password")
+    for key in ("live_list_ids", "movie_list_ids", "series_list_ids", "mixed_list_ids"):
+        if key in payload:
+            found[key] = payload.get(key) or []
     if "every_hours" in payload:
         found["every_hours"] = int(payload["every_hours"])
     if payload.get("refresh"):


### PR DESCRIPTION
## Summary
- allow renaming playlists and changing their URLs
- support editing Xtream credentials and playlist assignments
- add UI buttons for inline editing of playlists and Xtream entries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad65920004832cb717b0a2f5577de2