### PR TITLE
refactor: rename playlist type parameter

### DIFF
--- a/app/static/admin/admin.js
+++ b/app/static/admin/admin.js
@@ -265,7 +265,7 @@ function buildFullM3UUrl(x){
     buildServerUrl(x) +
     "/get.php?username=" + encodeURIComponent(x.username) +
     "&password=" + encodeURIComponent(x.password) +
-    "&type=m3u&output=ts"
+    "&playlist_type=m3u&output=ts"
   );
 }
 

--- a/app/xtream_manager.py
+++ b/app/xtream_manager.py
@@ -559,7 +559,7 @@ def xt_get_php(request: Request,
                xt_id: str,
                username: Optional[str] = None,
                password: Optional[str] = None,
-               type: str = "m3u",
+               playlist_type: str = "m3u",
                output: str = "ts"):
     if not username or not password:
         raise HTTPException(401, "Unauthorized")


### PR DESCRIPTION
## Summary
- rename `type` param to `playlist_type` in xtream playlist route
- update admin UI to use `playlist_type` query parameter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad91fb0ba8832cba205bc99ea3751a