### PR TITLE
URL-encode proxy target parameter

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ import json
 import time
 import uuid
 import urllib.parse
+from urllib.parse import quote
 from typing import Dict, List, Optional
 
 import httpx
@@ -123,7 +124,7 @@ class ResolveIn(BaseModel):
 def wrap_proxy(url: str, enabled: bool) -> str:
     if enabled and MEDIAFLOW_PROXY:
         base = MEDIAFLOW_PROXY.rstrip("/")
-        return f"{base}/fetch?target={url}"
+        return f"{base}/fetch?target={quote(url, safe='')}"
     return url
 
 def _handle_generic(url: str, kind: str, headers: Optional[Dict[str, str]], use_proxy: bool):

--- a/tests/test_wrap_proxy.py
+++ b/tests/test_wrap_proxy.py
@@ -1,0 +1,17 @@
+import pathlib
+import sys
+from urllib.parse import quote
+
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import app.main as main
+
+
+def test_wrap_proxy_encodes_target(monkeypatch):
+    monkeypatch.setattr(main, "MEDIAFLOW_PROXY", "http://proxy")
+    url = "http://example.com/a?b=1&c=2"
+    out = main.wrap_proxy(url, True)
+    assert out == f"http://proxy/fetch?target={quote(url, safe='')}"
+


### PR DESCRIPTION
## Summary
- encode proxy target parameter using urllib.parse.quote
- add regression test for wrap_proxy encoding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adcb1b867c832c98045ced4844a0d7