### PR TITLE
test: use urllib.parse.quote for wrap_proxy test

### DIFF
--- a/tests/test_wrap_proxy.py
+++ b/tests/test_wrap_proxy.py
@@ -1,0 +1,32 @@
+import importlib
+import sys
+from pathlib import Path
+import urllib.parse
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+def _get_wrap_proxy(monkeypatch, proxy=None):
+    if proxy is None:
+        monkeypatch.delenv("MEDIAFLOW_PROXY", raising=False)
+    else:
+        monkeypatch.setenv("MEDIAFLOW_PROXY", proxy)
+    import app.main as main
+    importlib.reload(main)
+    return main.wrap_proxy
+
+
+def test_wrap_proxy_wraps_url(monkeypatch):
+    wrap_proxy = _get_wrap_proxy(monkeypatch, "http://proxy")
+    url = "simple"
+    expected = f"http://proxy/fetch?target={urllib.parse.quote(url, safe='')}"
+    assert wrap_proxy(url, True) == expected
+
+
+def test_wrap_proxy_passthrough(monkeypatch):
+    wrap_proxy = _get_wrap_proxy(monkeypatch)
+    url = "simple"
+    assert wrap_proxy(url, True) == url
+    assert wrap_proxy(url, False) == url


### PR DESCRIPTION
## Summary
- ensure wrap_proxy test uses urllib.parse.quote for URL encoding
- add proxy wrapping and passthrough tests for wrap_proxy

## Testing
- `pytest tests/test_wrap_proxy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68add3382104832cb7414ee0d5a0e27d