### PR TITLE
Handle credential segments in Xtream URL patterns

### DIFF
--- a/app/xtream_manager.py
+++ b/app/xtream_manager.py
@@ -216,9 +216,20 @@ def _read_playlist(pl_id: str) -> List[M3UItem]:
         return []
 
 # ====== CLASSIFICAZIONE ======
-MOVIE_RE = re.compile(r"/movie/(\d+)", re.I)
-TV_RE    = re.compile(r"/(?:tv|series)/(\d+)/(?:season/)?(\d+)/(\d+)", re.I)
-TV_RE_SHORT = re.compile(r"/(?:tv|series)/(\d+)/(\d+)/(\d+)", re.I)
+# Paths from Xtream Codes often include username and password segments
+# before numeric identifiers. Allow two arbitrary segments after the base
+# prefix (``movie/`` or ``series|tv/``) so that URLs like
+# ``/series/user/pass/123/1/2.m3u8`` are recognised in addition to the
+# simpler ``/series/123/1/2`` form.
+MOVIE_RE = re.compile(r"/movie/(?:[^/]+/[^/]+/)?(\d+)", re.I)
+TV_RE    = re.compile(
+    r"/(?:tv|series)/(?:[^/]+/[^/]+/)?(\d+)/(?:season/)?(\d+)/(\d+)",
+    re.I,
+)
+TV_RE_SHORT = re.compile(
+    r"/(?:tv|series)/(?:[^/]+/[^/]+/)?(\d+)/(\d+)/(\d+)",
+    re.I,
+)
 
 def try_extract_movie_id(url: str) -> Optional[str]:
     m = MOVIE_RE.search(url)

--- a/tests/test_series_regex.py
+++ b/tests/test_series_regex.py
@@ -23,8 +23,17 @@ def xm(monkeypatch, tmp_path):
 def test_try_extract_tv_triplet_series(xm):
     url1 = "http://host/series/123/season/1/2"
     url2 = "http://host/series/123/1/2"
+    url3 = "http://host/series/user/pass/123/1/2.m3u8"
     assert xm.try_extract_tv_triplet(url1) == ("123", 1, 2)
     assert xm.try_extract_tv_triplet(url2) == ("123", 1, 2)
+    assert xm.try_extract_tv_triplet(url3) == ("123", 1, 2)
+
+
+def test_try_extract_movie_id(xm):
+    url1 = "http://host/movie/123/path"
+    url2 = "http://host/movie/user/pass/456.m3u8"
+    assert xm.try_extract_movie_id(url1) == "123"
+    assert xm.try_extract_movie_id(url2) == "456"
 
 
 def test_build_series_collections_series(xm):

--- a/tests/test_xtream_series.py
+++ b/tests/test_xtream_series.py
@@ -30,13 +30,15 @@ def test_try_extract_tv_triplet_series(tmp_path):
     xtm = import_xtm(tmp_path)
     url1 = "http://example.com/series/123/season/4/5"
     url2 = "http://example.com/series/123/4/5"
+    url3 = "http://example.com/series/user/pass/123/4/5.m3u8"
     assert xtm.try_extract_tv_triplet(url1) == ("123", 4, 5)
     assert xtm.try_extract_tv_triplet(url2) == ("123", 4, 5)
+    assert xtm.try_extract_tv_triplet(url3) == ("123", 4, 5)
 
 
 def test_build_series_collections_with_series_urls(tmp_path):
     xtm = import_xtm(tmp_path)
-    url = "http://example.com/series/123/season/2/3"
+    url = "http://example.com/series/user/pass/123/season/2/3.m3u8"
     item = xtm.M3UItem(
         title="My Show S02E03",
         url=url,


### PR DESCRIPTION
## Summary
- broaden Xtream movie and series regexes to allow optional username/password segments
- add tests verifying extraction from credentialed Xtream URLs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adf0b0e0e0832c81cd4f37fde05575