### PR TITLE
Ensure Xtream playlists expose durations for VOD and series

### DIFF
--- a/tests/test_build_streams.py
+++ b/tests/test_build_streams.py
@@ -42,9 +42,10 @@ def test_build_vod_streams_with_invalid_url(xm):
     item2 = _make_vod_item(xm, "Broken", "nota")
     streams, cat_map = xm.build_vod_streams(req, [item1, item2])
     assert len(streams) == 2
-    required_keys = {"num", "name", "stream_id", "stream_type", "stream_icon", "rating", "added", "category_id", "category_name", "container_extension", "direct_source"}
+    required_keys = {"num", "name", "stream_id", "stream_type", "stream_icon", "rating", "added", "duration", "category_id", "category_name", "container_extension", "direct_source"}
     for s in streams:
         assert required_keys <= s.keys()
+        assert int(s["duration"]) > 0
     s1, s2 = streams
     assert s1["stream_id"] == "123"
     assert s1["direct_source"] == f"http://testserver/video?u={xm.enc(item1.url)}"
@@ -81,6 +82,7 @@ def test_build_vod_info_and_not_found(xm):
     assert info["info"]["name"] == "Some Movie (2020)"
     assert info["info"]["movie_image"] == "poster.jpg"
     assert info["info"]["releasedate"] == "2020"
+    assert info["info"]["duration_secs"] == "1"
     with pytest.raises(xm.HTTPException) as exc:
         xm.build_vod_info(req, "999", [item])
     assert exc.value.status_code == 404

--- a/tests/test_series_regex.py
+++ b/tests/test_series_regex.py
@@ -41,3 +41,4 @@ def test_build_series_collections_series(xm):
     assert "123" in series_map
     episodes = series_map["123"]["episodes_by_season"]["1"]
     assert episodes[0]["title"] == "S01E02"
+    assert episodes[0]["info"]["duration"] == "1"

--- a/tests/test_xt_get_php.py
+++ b/tests/test_xt_get_php.py
@@ -1,0 +1,97 @@
+import importlib
+import os
+import pathlib
+import sys
+
+from starlette.requests import Request
+
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+def make_request():
+    return Request(
+        {
+            "type": "http",
+            "scheme": "http",
+            "server": ("test", 80),
+            "path": "/",
+            "headers": [],
+        }
+    )
+
+
+def test_xt_get_php_uses_durations(monkeypatch, tmp_path):
+    os_env = {
+        "CONFIG_DIR": str(tmp_path),
+        "APP_DIR": str(tmp_path),
+    }
+    for k, v in os_env.items():
+        monkeypatch.setenv(k, v)
+
+    import app.xtream_manager as xtm
+    importlib.reload(xtm)
+
+    live_item = xtm.M3UItem(
+        title="Live One",
+        url="http://example.com/live/abcdefabcdef",
+        attrs={},
+        group="Live",
+        tvg_id="",
+        tvg_logo="",
+        raw="",
+    )
+
+    vod_item = xtm.M3UItem(
+        title="Movie One",
+        url="http://example.com/movie/10/file",
+        attrs={"tvg-duration": "90"},
+        group="Film",
+        tvg_id="",
+        tvg_logo="",
+        raw="",
+    )
+
+    series_item = xtm.M3UItem(
+        title="Show S01E02",
+        url="http://example.com/series/20/season/1/2",
+        attrs={"tvg-duration": "40"},
+        group="Serie",
+        tvg_id="",
+        tvg_logo="",
+        raw="",
+    )
+
+    def fake_xtreams():
+        return [
+            {
+                "id": "1",
+                "username": "u",
+                "password": "p",
+                "live_list_ids": ["l"],
+                "movie_list_ids": ["v"],
+                "series_list_ids": ["s"],
+                "mixed_list_ids": [],
+            }
+        ]
+
+    def fake_read_playlist(pid):
+        return {
+            "l": [live_item],
+            "v": [vod_item],
+            "s": [series_item],
+        }.get(pid, [])
+
+    monkeypatch.setattr(xtm, "_xtreams", fake_xtreams)
+    monkeypatch.setattr(xtm, "_read_playlist", fake_read_playlist)
+
+    req = make_request()
+    resp = xtm.xt_get_php(req, "1", username="u", password="p")
+    body = resp.body.decode()
+    lines = body.strip().splitlines()
+
+    assert "#EXTINF:-1" in lines[1]
+    assert "#EXTINF:90" in lines[3]
+    assert "#EXTINF:40" in lines[5]
+

--- a/tests/test_xtream_series.py
+++ b/tests/test_xtream_series.py
@@ -53,3 +53,4 @@ def test_build_series_collections_with_series_urls(tmp_path):
     assert "2" in sm["episodes_by_season"]
     ep = sm["episodes_by_season"]["2"][0]
     assert ep["id"] == "123-S02E03"
+    assert ep["info"]["duration"] == "1"


### PR DESCRIPTION
## Summary
- derive duration from playlist attributes and default to 1s when missing
- include duration in VOD info, movie streams and series episodes
- output proper #EXTINF durations for VOD and series in xtream get.php

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68adf0393040832caa84f316e1c9b203