### PR TITLE
Add panel_api alias route for xtream manager

### DIFF
--- a/app/xtream_manager.py
+++ b/app/xtream_manager.py
@@ -618,6 +618,25 @@ def xt_player_api(request: Request,
 
     raise HTTPException(400, f"action non supportata: {action}")
 
+# ====== XTREAM: PANEL API (alias) ======
+@router.get("/xtream/{xt_id}/panel_api.php")
+def xt_panel_api(request: Request,
+                 xt_id: str,
+                 action: Optional[str] = None,
+                 username: Optional[str] = None,
+                 password: Optional[str] = None,
+                 vod_id: Optional[str] = None,
+                 series_id: Optional[str] = None):
+    return xt_player_api(
+        request,
+        xt_id,
+        action=action,
+        username=username,
+        password=password,
+        vod_id=vod_id,
+        series_id=series_id,
+    )
+
 # ====== XTREAM: GET.PHP (playlist M3U) ======
 @router.get("/xtream/{xt_id}/get.php")
 def xt_get_php(request: Request,

--- a/tests/test_xt_panel_api.py
+++ b/tests/test_xt_panel_api.py
@@ -1,0 +1,79 @@
+import importlib
+import os
+import pathlib
+import sys
+
+from starlette.requests import Request
+
+
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+def make_request():
+    return Request(
+        {
+            "type": "http",
+            "scheme": "http",
+            "server": ("test", 80),
+            "path": "/",
+            "headers": [],
+        }
+    )
+
+
+def test_panel_api_same_as_player_api(monkeypatch, tmp_path):
+    os_env = {
+        "CONFIG_DIR": str(tmp_path),
+        "APP_DIR": str(tmp_path),
+    }
+    for k, v in os_env.items():
+        monkeypatch.setenv(k, v)
+
+    import app.xtream_manager as xtm
+    importlib.reload(xtm)
+
+    live_item = xtm.M3UItem(
+        title="Live One",
+        url="http://example.com/live/abcdefabcdef",
+        attrs={},
+        group="Live",
+        tvg_id="",
+        tvg_logo="",
+        raw="",
+    )
+
+    def fake_xtreams():
+        return [
+            {
+                "id": "1",
+                "username": "u",
+                "password": "p",
+                "live_list_ids": ["l"],
+                "movie_list_ids": [],
+                "series_list_ids": [],
+                "mixed_list_ids": [],
+            }
+        ]
+
+    def fake_read_playlist(pid):
+        return {"l": [live_item]}.get(pid, [])
+
+    monkeypatch.setattr(xtm, "_xtreams", fake_xtreams)
+    monkeypatch.setattr(xtm, "_read_playlist", fake_read_playlist)
+
+    req = make_request()
+
+    resp_player = xtm.xt_player_api(
+        req, "1", username="u", password="p", action="get_live_streams"
+    )
+    resp_panel = xtm.xt_panel_api(
+        req, "1", username="u", password="p", action="get_live_streams"
+    )
+    assert resp_panel == resp_player
+
+    resp_player = xtm.xt_player_api(req, "1", username="u", password="p")
+    resp_panel = xtm.xt_panel_api(req, "1", username="u", password="p")
+    assert resp_panel == resp_player
+


### PR DESCRIPTION
## Summary
- add `panel_api.php` route that delegates to existing player API
- test that panel API responses mirror player API

## Testing
- `pytest tests/test_xt_panel_api.py tests/test_xt_get_php.py tests/test_xtream_series.py tests/test_build_streams.py tests/test_category_ids_lock.py tests/test_wrap_proxy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0bd27eec832c88efcfbc165bc7fd