### PR TITLE
Add root aliases for Xtream APIs

### DIFF
--- a/app/xtream_manager.py
+++ b/app/xtream_manager.py
@@ -619,6 +619,11 @@ def xt_player_api(request: Request,
     raise HTTPException(400, f"action non supportata: {action}")
 
 # ====== XTREAM: PANEL API (alias) ======
+#
+# In Xtream Codes the ``panel_api.php`` endpoint is just an alias of
+# ``player_api.php``.  We mimic the same behaviour both for the explicit
+# ``/xtream/{xt_id}/panel_api.php`` path and, for convenience, through
+# root-level aliases defined below.
 @router.get("/xtream/{xt_id}/panel_api.php")
 def xt_panel_api(request: Request,
                  xt_id: str,
@@ -628,6 +633,58 @@ def xt_panel_api(request: Request,
                  vod_id: Optional[str] = None,
                  series_id: Optional[str] = None):
     return xt_player_api(
+        request,
+        xt_id,
+        action=action,
+        username=username,
+        password=password,
+        vod_id=vod_id,
+        series_id=series_id,
+    )
+
+# ====== ROOT ALIASES ======
+# ``/player_api.php`` and ``/panel_api.php`` are convenience aliases for
+# clients that expect the classic Xtream Codes layout.  When a single Xtream
+# configuration is present, its identifier is used automatically; otherwise
+# callers must provide ``xt_id`` as a query parameter.
+
+@router.get("/player_api.php")
+def player_api(request: Request,
+               action: Optional[str] = None,
+               username: Optional[str] = None,
+               password: Optional[str] = None,
+               xt_id: Optional[str] = None,
+               vod_id: Optional[str] = None,
+               series_id: Optional[str] = None):
+    xts = _xtreams()
+    if len(xts) == 1 and not xt_id:
+        xt_id = xts[0].get("id")
+    elif not xt_id:
+        raise HTTPException(400, "xt_id mancante")
+    return xt_player_api(
+        request,
+        xt_id,
+        action=action,
+        username=username,
+        password=password,
+        vod_id=vod_id,
+        series_id=series_id,
+    )
+
+@router.get("/panel_api.php")
+def panel_api(request: Request,
+              action: Optional[str] = None,
+              username: Optional[str] = None,
+              password: Optional[str] = None,
+              xt_id: Optional[str] = None,
+              vod_id: Optional[str] = None,
+              series_id: Optional[str] = None):
+    xts = _xtreams()
+    if len(xts) == 1 and not xt_id:
+        xt_id = xts[0].get("id")
+    elif not xt_id:
+        raise HTTPException(400, "xt_id mancante")
+    return xt_panel_api(
         request,
         xt_id,
         action=action,

--- a/tests/test_xt_panel_api.py
+++ b/tests/test_xt_panel_api.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import sys
 
+import pytest
 from starlette.requests import Request
 
 
@@ -23,7 +24,7 @@ def make_request():
     )
 
 
-def test_panel_api_same_as_player_api(monkeypatch, tmp_path):
+def setup_env(monkeypatch, tmp_path):
     os_env = {
         "CONFIG_DIR": str(tmp_path),
         "APP_DIR": str(tmp_path),
@@ -33,6 +34,11 @@ def test_panel_api_same_as_player_api(monkeypatch, tmp_path):
 
     import app.xtream_manager as xtm
     importlib.reload(xtm)
+    return xtm
+
+
+def test_panel_api_same_as_player_api(monkeypatch, tmp_path):
+    xtm = setup_env(monkeypatch, tmp_path)
 
     live_item = xtm.M3UItem(
         title="Live One",
@@ -76,4 +82,174 @@ def test_panel_api_same_as_player_api(monkeypatch, tmp_path):
     resp_player = xtm.xt_player_api(req, "1", username="u", password="p")
     resp_panel = xtm.xt_panel_api(req, "1", username="u", password="p")
     assert resp_panel == resp_player
+
+
+def test_root_player_api_uses_single_xtream(monkeypatch, tmp_path):
+    xtm = setup_env(monkeypatch, tmp_path)
+
+    live_item = xtm.M3UItem(
+        title="Live One",
+        url="http://example.com/live/abcdefabcdef",
+        attrs={},
+        group="Live",
+        tvg_id="",
+        tvg_logo="",
+        raw="",
+    )
+
+    def fake_xtreams():
+        return [
+            {
+                "id": "1",
+                "username": "u",
+                "password": "p",
+                "live_list_ids": ["l"],
+                "movie_list_ids": [],
+                "series_list_ids": [],
+                "mixed_list_ids": [],
+            }
+        ]
+
+    def fake_read_playlist(pid):
+        return {"l": [live_item]}.get(pid, [])
+
+    monkeypatch.setattr(xtm, "_xtreams", fake_xtreams)
+    monkeypatch.setattr(xtm, "_read_playlist", fake_read_playlist)
+
+    req = make_request()
+    resp_root = xtm.player_api(req, username="u", password="p", action="get_live_streams")
+    resp_player = xtm.xt_player_api(
+        req, "1", username="u", password="p", action="get_live_streams"
+    )
+    assert resp_root == resp_player
+
+
+def test_root_player_api_requires_xt_id(monkeypatch, tmp_path):
+    xtm = setup_env(monkeypatch, tmp_path)
+
+    def fake_xtreams():
+        return [
+            {
+                "id": "1",
+                "username": "u1",
+                "password": "p1",
+                "live_list_ids": [],
+                "movie_list_ids": [],
+                "series_list_ids": [],
+                "mixed_list_ids": [],
+            },
+            {
+                "id": "2",
+                "username": "u2",
+                "password": "p2",
+                "live_list_ids": [],
+                "movie_list_ids": [],
+                "series_list_ids": [],
+                "mixed_list_ids": [],
+            },
+        ]
+
+    monkeypatch.setattr(xtm, "_xtreams", fake_xtreams)
+
+    req = make_request()
+    with pytest.raises(xtm.HTTPException) as exc:
+        xtm.player_api(req, username="u1", password="p1", action="get_live_streams")
+    assert exc.value.status_code == 400
+
+
+def test_root_player_api_accepts_xt_id(monkeypatch, tmp_path):
+    xtm = setup_env(monkeypatch, tmp_path)
+
+    live_item = xtm.M3UItem(
+        title="Live One",
+        url="http://example.com/live/abcdefabcdef",
+        attrs={},
+        group="Live",
+        tvg_id="",
+        tvg_logo="",
+        raw="",
+    )
+
+    def fake_xtreams():
+        return [
+            {
+                "id": "1",
+                "username": "u1",
+                "password": "p1",
+                "live_list_ids": ["l"],
+                "movie_list_ids": [],
+                "series_list_ids": [],
+                "mixed_list_ids": [],
+            },
+            {
+                "id": "2",
+                "username": "u2",
+                "password": "p2",
+                "live_list_ids": [],
+                "movie_list_ids": [],
+                "series_list_ids": [],
+                "mixed_list_ids": [],
+            },
+        ]
+
+    def fake_read_playlist(pid):
+        return {"l": [live_item]}.get(pid, [])
+
+    monkeypatch.setattr(xtm, "_xtreams", fake_xtreams)
+    monkeypatch.setattr(xtm, "_read_playlist", fake_read_playlist)
+
+    req = make_request()
+    resp_root = xtm.player_api(
+        req,
+        username="u1",
+        password="p1",
+        xt_id="1",
+        action="get_live_streams",
+    )
+    resp_player = xtm.xt_player_api(
+        req, "1", username="u1", password="p1", action="get_live_streams"
+    )
+    assert resp_root == resp_player
+
+
+def test_root_panel_api_alias(monkeypatch, tmp_path):
+    xtm = setup_env(monkeypatch, tmp_path)
+
+    live_item = xtm.M3UItem(
+        title="Live One",
+        url="http://example.com/live/abcdefabcdef",
+        attrs={},
+        group="Live",
+        tvg_id="",
+        tvg_logo="",
+        raw="",
+    )
+
+    def fake_xtreams():
+        return [
+            {
+                "id": "1",
+                "username": "u",
+                "password": "p",
+                "live_list_ids": ["l"],
+                "movie_list_ids": [],
+                "series_list_ids": [],
+                "mixed_list_ids": [],
+            }
+        ]
+
+    def fake_read_playlist(pid):
+        return {"l": [live_item]}.get(pid, [])
+
+    monkeypatch.setattr(xtm, "_xtreams", fake_xtreams)
+    monkeypatch.setattr(xtm, "_read_playlist", fake_read_playlist)
+
+    req = make_request()
+    resp_root = xtm.panel_api(
+        req, username="u", password="p", action="get_live_streams"
+    )
+    resp_panel = xtm.xt_panel_api(
+        req, "1", username="u", password="p", action="get_live_streams"
+    )
+    assert resp_root == resp_panel
 


### PR DESCRIPTION
## Summary
- expose root-level `/player_api.php` and `/panel_api.php` endpoints that proxy to existing Xtream APIs
- auto-select the single configured Xtream or require explicit `xt_id`
- document alias behaviour and add tests for new routes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae13fd91bc832cb02695e057371109