### PR TITLE
Handle encoded TV URLs in xtream manager

### DIFF
--- a/app/xtream_manager.py
+++ b/app/xtream_manager.py
@@ -239,6 +239,12 @@ def try_extract_movie_id(url: str) -> Optional[str]:
     return m.group(1) if m else None
 
 def try_extract_tv_triplet(url: str) -> Optional[Tuple[str, int, int]]:
+    parsed = urllib.parse.urlparse(url)
+    q = urllib.parse.parse_qs(parsed.query)
+    if "u" in q and q["u"]:
+        url = urllib.parse.unquote(q["u"][0])
+    else:
+        url = urllib.parse.unquote(url)
     for rgx in (TV_RE, TV_RE_SHORT):
         m = rgx.search(url)
         if m:

--- a/tests/test_xtream_series.py
+++ b/tests/test_xtream_series.py
@@ -56,3 +56,24 @@ def test_build_series_collections_with_series_urls(tmp_path):
     ep = sm["episodes_by_season"]["2"][0]
     assert ep["id"] == "123-S02E03"
     assert ep["info"]["duration"] == "1"
+
+
+def test_build_series_collections_with_wrapped_url(tmp_path):
+    xtm = import_xtm(tmp_path)
+    url = "http://example.com/video?u=https%3A%2F%2Fvixsrc.to%2Ftv%2F123%2Fseason%2F2%2F3"
+    item = xtm.M3UItem(
+        title="My Show S02E03",
+        url=url,
+        attrs={},
+        group="Serie",
+        tvg_id="",
+        tvg_logo="",
+        raw="",
+    )
+    req = make_request()
+    series_map, cat_map = xtm.build_series_collections(req, [item])
+    assert "123" in series_map
+    sm = series_map["123"]
+    assert "2" in sm["episodes_by_season"]
+    ep = sm["episodes_by_season"]["2"][0]
+    assert ep["id"] == "123-S02E03"


### PR DESCRIPTION
## Summary
- Decode `video?u=` URLs before applying TV regex
- Test that wrapped TV URLs are recognized when building series collections

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aea95cad00832c93680d87bf748b60