### PR TITLE
Handle encoded movie URLs in Xtream manager

### DIFF
--- a/app/xtream_manager.py
+++ b/app/xtream_manager.py
@@ -235,6 +235,18 @@ TV_RE_SHORT = re.compile(
 )
 
 def try_extract_movie_id(url: str) -> Optional[str]:
+    parsed = urllib.parse.urlparse(url)
+    q = urllib.parse.parse_qs(parsed.query)
+    if "u" in q and q["u"]:
+        target_url = q["u"][0]
+        while True:
+            dec = urllib.parse.unquote(target_url)
+            if dec == target_url:
+                break
+            target_url = dec
+        m = MOVIE_RE.search(target_url)
+        if m:
+            return m.group(1)
     m = MOVIE_RE.search(url)
     return m.group(1) if m else None
 

--- a/tests/test_xtream_movies.py
+++ b/tests/test_xtream_movies.py
@@ -1,0 +1,24 @@
+import pathlib
+import sys
+import importlib
+import urllib.parse
+
+import pytest
+
+
+@pytest.fixture
+def xm(monkeypatch, tmp_path):
+    monkeypatch.setenv("CONFIG_DIR", str(tmp_path))
+    root = pathlib.Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    import app.xtream_manager as module
+    importlib.reload(module)
+    return module
+
+
+def test_try_extract_movie_id_wrapped(xm):
+    inner = "http://host/movie/789"
+    encoded = urllib.parse.quote(urllib.parse.quote(inner, safe=""), safe="")
+    url = f"http://wrapper/video?u={encoded}"
+    assert xm.try_extract_movie_id(url) == "789"


### PR DESCRIPTION
## Summary
- decode wrapped `u` query parameter in `try_extract_movie_id`
- add regression test for movies wrapped in `video` links

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aead8a8a3c832c8de4907d1d1006a2