### PR TITLE
Add request logging middleware

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ import uuid
 from typing import Dict, List, Optional
 
 import httpx
-from fastapi import Body, FastAPI, HTTPException, Path, Query
+from fastapi import Body, FastAPI, HTTPException, Path, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import (FileResponse, HTMLResponse, JSONResponse,
                                PlainTextResponse, RedirectResponse)
@@ -236,6 +236,14 @@ def _find_playlist(items: List[Dict], pid: str) -> Optional[Dict]:
 # FastAPI app
 # -----------------------------------------------------------------------------
 APP = FastAPI(title="Stream Resolver", version="1.2.0")
+
+@APP.middleware("http")
+async def log_requests(request: Request, call_next):
+    logger.info("HTTP %s %s headers=%s",
+                request.method,
+                str(request.url),
+                dict(request.headers))
+    return await call_next(request)
 
 APP.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- log HTTP requests with method, URL and headers

## Testing
- `pytest`
- `uvicorn app.main:APP --port 8000 --log-level info`

------
https://chatgpt.com/codex/tasks/task_e_68aeb6ad5c88832caccda5590cbd8107