### PR TITLE
Include stream counts in default Xtream API response

### DIFF
--- a/app/xtream_manager.py
+++ b/app/xtream_manager.py
@@ -555,6 +555,10 @@ def xt_player_api(request: Request,
     movie_items = items_for_xtream_selection(xt.get("movie_list_ids", []) + xt.get("mixed_list_ids", []))
     series_items= items_for_xtream_selection(xt.get("series_list_ids", []) + xt.get("mixed_list_ids", []))
 
+    available_channels = len(live_items)
+    available_movies = len(movie_items)
+    available_series = len(series_items)
+
     if action is None:
         return {
             "user_info": {
@@ -567,7 +571,10 @@ def xt_player_api(request: Request,
                 "https_port": "",
                 "server_protocol": "http",
                 "timezone": "UTC"
-            }
+            },
+            "available_channels": available_channels,
+            "available_movies": available_movies,
+            "available_series": available_series,
         }
 
     if action == "get_live_categories":

--- a/tests/test_xt_panel_api.py
+++ b/tests/test_xt_panel_api.py
@@ -79,6 +79,63 @@ def test_panel_api_same_as_player_api(monkeypatch, tmp_path):
     )
     assert resp_panel == resp_player
 
+
+def test_default_response_contains_counts(monkeypatch, tmp_path):
+    xtm = setup_env(monkeypatch, tmp_path)
+
+    live_item = xtm.M3UItem(
+        title="Live One",
+        url="http://example.com/live/abcdefabcdef",
+        attrs={},
+        group="Live",
+        tvg_id="",
+        tvg_logo="",
+        raw="",
+    )
+    movie_item = xtm.M3UItem(
+        title="Movie One",
+        url="http://example.com/movie/abcdefabcdef",
+        attrs={},
+        group="Movie",
+        tvg_id="",
+        tvg_logo="",
+        raw="",
+    )
+    series_item = xtm.M3UItem(
+        title="Series One",
+        url="http://example.com/series/abcdefabcdef",
+        attrs={},
+        group="Series",
+        tvg_id="",
+        tvg_logo="",
+        raw="",
+    )
+
+    def fake_xtreams():
+        return [
+            {
+                "id": "1",
+                "username": "u",
+                "password": "p",
+                "live_list_ids": ["l"],
+                "movie_list_ids": ["m"],
+                "series_list_ids": ["s"],
+                "mixed_list_ids": [],
+            }
+        ]
+
+    def fake_read_playlist(pid):
+        return {"l": [live_item], "m": [movie_item], "s": [series_item]}.get(pid, [])
+
+    monkeypatch.setattr(xtm, "_xtreams", fake_xtreams)
+    monkeypatch.setattr(xtm, "_read_playlist", fake_read_playlist)
+
+    req = make_request()
+    resp = xtm.xt_player_api(req, "1", username="u", password="p")
+    assert resp["available_channels"] == 1
+    assert resp["available_movies"] == 1
+    assert resp["available_series"] == 1
+
     resp_player = xtm.xt_player_api(req, "1", username="u", password="p")
     resp_panel = xtm.xt_panel_api(req, "1", username="u", password="p")
     assert resp_panel == resp_player


### PR DESCRIPTION
## Summary
- return available channel, movie, and series counts in default xtream player response
- add regression test ensuring counts are present on first request

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aec07fdd8c832cb4399cd436b9fcc1