### PR TITLE
Handle video playlist comments and group titles

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -194,12 +194,16 @@ def convert_playlist_text(src_text: str, mode: str, settings: Dict[str, str]) ->
     out: List[str] = []
     saw_header = False
     for line in lines:
-        if not saw_header and M3U_HEADER_RE.match(line.strip()):
+        stripped = line.strip()
+        if not saw_header and M3U_HEADER_RE.match(stripped):
             saw_header = True
-        if line.strip().startswith("#"):
+        if stripped.startswith("#"):
+            if mode == "video" and not stripped.startswith("#EXT"):
+                continue
+            if mode == "video" and stripped.startswith("#EXTINF"):
+                line = re.sub(r'\s*group-title="[^"]*"', "", line)
             out.append(line)
             continue
-        stripped = line.strip()
         if stripped.lower().startswith(("http://", "https://")):
             out.append(_resolver_link_for(stripped, settings, mode))
         elif stripped == "":


### PR DESCRIPTION
## Summary
- Skip non-`#EXT` comment lines when converting video playlists
- Remove `group-title` attribute from `#EXTINF` entries in video playlists

## Testing
- `python -m py_compile app/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af51352df8832c824930d23fdbedd2